### PR TITLE
Modernise to Livewire 4: replace getEventsProperty() with events()

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,11 +16,11 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
 
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@v3
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan --error-format=github

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,20 +8,14 @@ on:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        php: [8.2, 8.1]
-        laravel: [10.*]
+        php: [8.2, 8.3, 8.4]
         stability: [prefer-lowest, prefer-stable]
-        include:
-          - laravel: 10.*
-            testbench: 8.*
-            carbon: ^2.63
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout code
@@ -34,18 +28,8 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
           coverage: none
 
-      - name: Setup problem matchers
-        run: |
-          echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
       - name: Install dependencies
-        run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
-
-      - name: List Installed Dependencies
-        run: composer show -D
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
         run: vendor/bin/pest --ci

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,9 +2,11 @@ name: run-tests
 
 on:
   push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - 'phpunit.xml.dist'
+      - '.github/workflows/run-tests.yml'
 
 jobs:
   test:

--- a/composer.json
+++ b/composer.json
@@ -22,17 +22,18 @@
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
-        "larastan/larastan": "^2.0.1",
+        "larastan/larastan": "^3.0",
+        "laravel/boost": "^2.2",
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.8",
-        "orchestra/testbench": "^8.8",
-        "pestphp/pest": "^2.20",
-        "pestphp/pest-plugin-arch": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0",
-        "pestphp/pest-plugin-livewire": "^2.1",
+        "nunomaduro/collision": "^8.0",
+        "orchestra/testbench": "^9.0",
+        "pestphp/pest": "^3.0",
+        "pestphp/pest-plugin-arch": "^3.0",
+        "pestphp/pest-plugin-laravel": "^3.0",
+        "pestphp/pest-plugin-livewire": "^3.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
         "spatie/laravel-ray": "^1.26"
     },
     "autoload": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,9 +6,7 @@ parameters:
     paths:
         - src
         - config
-        - database
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
 

--- a/resources/views/calendar.blade.php
+++ b/resources/views/calendar.blade.php
@@ -1,7 +1,7 @@
 <div wire:ignore>
     <div x-data="{
         calendar: null,
-        events: @js($this->events),
+        events: @js($this->events()),
         init() {
             this.calendar = new FullCalendar.Calendar(this.$refs.calendar, {
                 events: (info, success) => success(this.events),

--- a/src/LivewireCalendar.php
+++ b/src/LivewireCalendar.php
@@ -23,7 +23,7 @@ abstract class LivewireCalendar extends Component
     use WithToolbar;
     use WithView;
 
-    abstract public function getEventsProperty(): array;
+    abstract public function events(): array;
 
     abstract public function eventClick($info): void;
 

--- a/tests/Testables/TestCalendar.php
+++ b/tests/Testables/TestCalendar.php
@@ -6,7 +6,7 @@ use ACTTraining\LivewireCalendar\LivewireCalendar;
 
 class TestCalendar extends LivewireCalendar
 {
-    public function getEventsProperty(): array
+    public function events(): array
     {
         return [];
     }


### PR DESCRIPTION
## Summary
- Rename abstract `getEventsProperty()` to `events()` across the package
- Update blade view to call `$this->events()` as a method instead of a computed property
- Upgrade dev dependencies to Laravel 11 / Pest 3 / PHPStan 2
- Simplify CI test matrix: drop Windows, update PHP to 8.2–8.4, remove hardcoded Laravel version matrix
- Fix PHPStan workflow and config for PHPStan 2

## Test plan
- [x] Existing tests pass locally
- [x] PHPStan passes locally and in CI
- [ ] CI `run-tests` passes on all PHP versions
- [ ] Consuming apps rename `getEventsProperty()` → `events()`

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)